### PR TITLE
S-007: Host cards — roles, GPU type, resource availability + WebUI lint/format

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -9,6 +9,7 @@ export type BackendType = 'llamacpp' | 'huggingface_causal' | 'huggingface_class
 export interface MemoryInfo {
   used_gb: number;
   total_gb: number;
+  available_gb?: number;
   percent: number;
   memory_type: string;
 }
@@ -250,6 +251,11 @@ export interface Host {
   last_seen?: string;
   memory?: MemoryInfo;
   gpu_type?: string;
+  roles?: string[];
+  disk_total_gb?: number;
+  disk_used_gb?: number;
+  disk_available_gb?: number;
+  memory_available_gb?: number;
   created_at: string;
 }
 

--- a/src/components/HostCard.tsx
+++ b/src/components/HostCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback } from 'react';
 import { Instance, InstanceConfig, MemoryInfo, getModelCategory, ModelCategory } from '@/api/types';
-import { cn, getStatusColor, formatDate, getMemoryColor, formatMemoryUsage } from '@/lib/utils';
+import { cn, getStatusColor, formatDate, getMemoryColor, formatMemoryUsage, formatDiskUsage } from '@/lib/utils';
 import { InstanceCard } from './InstanceCard';
 import { AddInstanceModal } from './AddInstanceModal';
 import {
@@ -15,6 +15,8 @@ import {
   GripVertical,
   Cpu,
   Microchip,
+  HardDrive,
+  MemoryStick,
 } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -39,6 +41,10 @@ interface HostCardProps {
     last_seen?: string;
     memory?: MemoryInfo;
     gpu_type?: string;
+    roles?: string[];
+    disk_total_gb?: number;
+    disk_used_gb?: number;
+    disk_available_gb?: number;
     instances: Instance[];
   };
   hostReachable: boolean;
@@ -90,6 +96,17 @@ const getGpuTypeBadgeClass = (gpuType: string): string => {
       return 'bg-nord-3 text-nord-6';
     default:
       return 'bg-nord-3 text-nord-6';
+  }
+};
+
+const getRoleBadgeClass = (role: string): string => {
+  switch (role) {
+    case 'inference':
+      return 'bg-nord-6 bg-opacity-20 text-nord-6';
+    case 'training':
+      return 'bg-nord-15 text-nord-6';
+    default:
+      return 'bg-nord-6 bg-opacity-15 text-nord-6';
   }
 };
 
@@ -252,6 +269,16 @@ export function HostCard({
               </div>
             </div>
             <div className="flex items-center gap-2">
+              {host.roles &&
+                host.roles.length > 0 &&
+                host.roles.map((role) => (
+                  <span
+                    key={role}
+                    className={cn('px-2 py-1 rounded-full text-xs font-medium', getRoleBadgeClass(role))}
+                  >
+                    {role}
+                  </span>
+                ))}
               {host.gpu_type && (
                 <span
                   className={cn(
@@ -333,13 +360,38 @@ export function HostCard({
           {host.memory && (
             <div className="mt-3 space-y-1">
               <div className="flex items-center justify-between text-xs text-nord-4">
-                <span className="font-medium">{host.memory.memory_type} Usage:</span>
+                <span className="font-medium flex items-center gap-1">
+                  <MemoryStick size={12} />
+                  {host.memory.memory_type} Usage:
+                </span>
                 <span>{formatMemoryUsage(host.memory.used_gb, host.memory.total_gb, host.memory.percent)}</span>
               </div>
               <div className="w-full h-2 bg-nord-2 rounded-full overflow-hidden">
                 <div
                   className={cn('h-full transition-all duration-300 rounded-full', getMemoryColor(host.memory.percent))}
                   style={{ width: `${Math.min(host.memory.percent, 100)}%` }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Disk Usage */}
+          {host.disk_total_gb != null && host.disk_used_gb != null && host.disk_total_gb > 0 && (
+            <div className="mt-2 space-y-1">
+              <div className="flex items-center justify-between text-xs text-nord-4">
+                <span className="font-medium flex items-center gap-1">
+                  <HardDrive size={12} />
+                  Disk Usage:
+                </span>
+                <span>{formatDiskUsage(host.disk_used_gb, host.disk_total_gb)}</span>
+              </div>
+              <div className="w-full h-2 bg-nord-2 rounded-full overflow-hidden">
+                <div
+                  className={cn(
+                    'h-full transition-all duration-300 rounded-full',
+                    getMemoryColor((host.disk_used_gb / host.disk_total_gb) * 100),
+                  )}
+                  style={{ width: `${Math.min((host.disk_used_gb / host.disk_total_gb) * 100, 100)}%` }}
                 />
               </div>
             </div>

--- a/src/hooks/useEventStream.ts
+++ b/src/hooks/useEventStream.ts
@@ -52,6 +52,11 @@ export interface HostStatusData {
   url?: string;
   memory?: MemoryInfo;
   gpu_type?: string;
+  roles?: string[];
+  disk_total_gb?: number;
+  disk_used_gb?: number;
+  disk_available_gb?: number;
+  memory_available_gb?: number;
   connected?: boolean;
   last_seen?: string;
   timestamp?: string;
@@ -342,8 +347,15 @@ export function useEventStream(handlers: EventHandlers = {}) {
               if (existing) {
                 newMap.set(hostId, {
                   ...existing,
-                  memory: event.data.memory,
+                  memory: event.data.memory ?? existing.memory,
                   ...(event.data.gpu_type && { gpu_type: event.data.gpu_type }),
+                  ...(event.data.roles && { roles: event.data.roles }),
+                  ...(event.data.disk_total_gb != null && { disk_total_gb: event.data.disk_total_gb }),
+                  ...(event.data.disk_used_gb != null && { disk_used_gb: event.data.disk_used_gb }),
+                  ...(event.data.disk_available_gb != null && { disk_available_gb: event.data.disk_available_gb }),
+                  ...(event.data.memory_available_gb != null && {
+                    memory_available_gb: event.data.memory_available_gb,
+                  }),
                 });
               }
               return newMap;
@@ -518,11 +530,21 @@ export function useEventStream(handlers: EventHandlers = {}) {
       bindEvent('host_pending', (payload) => ({ type: 'host_pending', data: payload }));
       bindEvent('host_pending_removed', (payload) => ({ type: 'host_pending_removed', data: payload }));
       bindEvent('instances_update', (payload) => ({ type: 'instances_update', data: payload }));
-      bindEvent('host_health', (payload) => ({
-        type: 'host_health',
-        host_id: payload?.host_id,
-        data: payload?.data ?? payload,
-      }));
+      bindEvent('host_health', (payload) => {
+        const raw = payload?.data ?? payload;
+        return {
+          type: 'host_health',
+          host_id: payload?.host_id,
+          data: {
+            ...raw,
+            ...(payload?.memory && { memory: payload.memory }),
+            ...(payload?.disk_total_gb != null && { disk_total_gb: payload.disk_total_gb }),
+            ...(payload?.disk_used_gb != null && { disk_used_gb: payload.disk_used_gb }),
+            ...(payload?.disk_available_gb != null && { disk_available_gb: payload.disk_available_gb }),
+            ...(payload?.memory_available_gb != null && { memory_available_gb: payload.memory_available_gb }),
+          },
+        };
+      });
       bindEvent('instance_state', (payload) => ({
         type: 'instance_state',
         host_id: payload?.host_id,

--- a/src/hooks/useInstances.ts
+++ b/src/hooks/useInstances.ts
@@ -292,6 +292,11 @@ export function useInstances() {
             status: wsStatus.status as any,
             memory: wsStatus.memory || host.memory,
             gpu_type: wsStatus.gpu_type || host.gpu_type,
+            roles: wsStatus.roles || host.roles,
+            disk_total_gb: wsStatus.disk_total_gb ?? host.disk_total_gb,
+            disk_used_gb: wsStatus.disk_used_gb ?? host.disk_used_gb,
+            disk_available_gb: wsStatus.disk_available_gb ?? host.disk_available_gb,
+            memory_available_gb: wsStatus.memory_available_gb ?? host.memory_available_gb,
           }
         : host;
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -95,6 +95,11 @@ export function formatMemoryUsage(used: number, total: number, percent: number):
   return `${used.toFixed(1)} / ${total.toFixed(1)} GB (${percent.toFixed(1)}%)`;
 }
 
+export function formatDiskUsage(used: number, total: number): string {
+  const percent = total > 0 ? (used / total) * 100 : 0;
+  return `${used.toFixed(1)} / ${total.toFixed(1)} GB (${percent.toFixed(1)}%)`;
+}
+
 export function formatTokenCount(count: number | undefined | null): string {
   if (count === undefined || count === null || isNaN(count)) {
     return '—';


### PR DESCRIPTION
## Description

Extends Solar WebUI so operators can see host **roles**, **GPU/acceleration type**, and **disk + memory** usage on host cards, with data coming from `GET /api/hosts` and Socket.IO (`host_status`, `host_health`). Adds **ESLint + Prettier** with `npm run lint` / `npm run lint:fix`. Table view keeps the Host column to **hostname only** (no GPU/role chips there).

## Changes

- **`src/api/types.ts`** — `MemoryInfo.available_gb`; `Host`: `roles`, `disk_*`, `memory_available_gb`
- **`src/hooks/useEventStream.ts`** — `HostStatusData` extended; `host_health` merges roles/disk/memory fields; `host_health` binding merges top-level DB fields from control into `data`
- **`src/hooks/useInstances.ts`** — Merges socket `roles`, `disk_*`, `memory_available_gb` into merged hosts
- **`src/components/HostCard.tsx`** — Role badges (higher contrast on gradient header), GPU badge, VRAM/RAM bar with **MemoryStick** icon, disk bar with **HardDrive** + `formatDiskUsage`
- **`src/lib/utils.ts`** — `formatDiskUsage`
- **`src/components/UnifiedTable.tsx`** — Host column: name + offline dot only (no GPU/roles in table)
- **Tooling** — `eslint.config.js`, `.prettierrc`, `package.json` scripts `lint` / `lint:fix`; `useHostStatus` eslint suppression for dynamic context pattern
- Resolved merge conflicts between feature branch and Prettier-formatted base (`HostCard`, `useEventStream`)

## Related Issues

Closes #6 