### PR TITLE
Fix WebUI instance create/update when KV cache and RoPE fields use Default

### DIFF
--- a/src/components/AddInstanceModal.tsx
+++ b/src/components/AddInstanceModal.tsx
@@ -196,6 +196,19 @@ export function AddInstanceModal({ hostId, hostName, onClose, onCreate }: AddIns
         .filter((l) => l);
     }
 
+    // Strip empty strings from optional fields so the backend receives None
+    // and llama.cpp uses its own defaults
+    if (primaryBackend === 'llamacpp') {
+      const c = finalConfig as Partial<LlamaCppConfig>;
+      if (!c.cache_type_k) delete c.cache_type_k;
+      if (!c.cache_type_v) delete c.cache_type_v;
+      if (!c.rope_scaling) delete c.rope_scaling;
+      if (!c.chat_template_file) delete c.chat_template_file;
+      if (!c.chat_template_kwargs) delete c.chat_template_kwargs;
+      if (!c.ot) delete c.ot;
+      if (!c.pooling) delete c.pooling;
+    }
+
     setLoading(true);
     try {
       await onCreate(hostId, finalConfig as InstanceConfig);

--- a/src/components/EditInstanceModal.tsx
+++ b/src/components/EditInstanceModal.tsx
@@ -101,6 +101,19 @@ export function EditInstanceModal({ instance, hostId, onClose, onUpdate }: EditI
         .filter((l) => l);
     }
 
+    // Strip empty strings from optional fields so the backend receives None
+    // and llama.cpp uses its own defaults
+    if (isLlamaCppConfig(formData)) {
+      const c = finalConfig as Partial<LlamaCppConfig>;
+      if (!c.cache_type_k) delete c.cache_type_k;
+      if (!c.cache_type_v) delete c.cache_type_v;
+      if (!c.rope_scaling) delete c.rope_scaling;
+      if (!c.chat_template_file) delete c.chat_template_file;
+      if (!c.chat_template_kwargs) delete c.chat_template_kwargs;
+      if (!c.ot) delete c.ot;
+      if (!c.pooling) delete c.pooling;
+    }
+
     setLoading(true);
     try {
       await onUpdate(hostId, instance.id, finalConfig);


### PR DESCRIPTION
## Description
Creating or editing a llama.cpp instance with Cache Type K, Cache Type V, or RoPE Scaling left on “Default” sent empty strings in the JSON body. The host API validates these as optional literals (`None` or a specific enum), so `""` caused validation errors. This PR omits those optional fields when they are empty so the backend gets `null`/missing keys and does not pass extra llama.cpp flags—matching llama.cpp defaults.
## Changes
- **AddInstanceModal.tsx** — Before create, delete empty optional llama.cpp fields: `cache_type_k`, `cache_type_v`, `rope_scaling`, plus `chat_template_file`, `chat_template_kwargs`, `ot`, and `pooling` when unset.
- **EditInstanceModal.tsx** — Same cleanup before update for llama.cpp configs.
## Reproduction Steps
1. Open Add Instance (or Edit) for a llama.cpp instance.
2. Leave Cache Type K, Cache Type V, and RoPE Scaling on **Default**.
3. Fill required fields and submit.
4. **Before:** API validation error from host. **After:** Request succeeds; host omits `-ctk`, `-ctv`, and `--rope-scaling` when not set.
## Related Issues
Fixes #10 