### PR TITLE
feat: add Draft MTP speculative decoding options to LlamaCpp modals

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -42,6 +42,8 @@ export interface LlamaCppConfig extends BaseInstanceConfig {
   chat_template_kwargs?: string;
   reasoning?: 'on' | 'off' | 'auto';
   reasoning_budget?: number;
+  spec_type?: 'draft-mtp';
+  spec_draft_n_max?: number;
   cache_type_k?: string;
   cache_type_v?: string;
   rope_scaling?: string;

--- a/src/components/AddInstanceModal.tsx
+++ b/src/components/AddInstanceModal.tsx
@@ -210,6 +210,7 @@ export function AddInstanceModal({ hostId, hostName, onClose, onCreate }: AddIns
       if (!c.ot) delete c.ot;
       if (!c.mmproj) delete c.mmproj;
       if (!c.pooling) delete c.pooling;
+      if (!c.spec_type) delete c.spec_draft_n_max;
     }
 
     setLoading(true);
@@ -403,9 +404,7 @@ export function AddInstanceModal({ hostId, hostName, onClose, onCreate }: AddIns
                   {/* Multimodal projector GPU offload — only when mmproj is set */}
                   {llamaCppMode === 'llm' && (formData as Partial<LlamaCppConfig>).mmproj && (
                     <div className="md:col-span-2">
-                      <label className="block text-sm font-medium text-nord-4 mb-1">
-                        Projector GPU Offload
-                      </label>
+                      <label className="block text-sm font-medium text-nord-4 mb-1">Projector GPU Offload</label>
                       <select
                         name="mmproj_offload"
                         value={(formData as Partial<LlamaCppConfig>).mmproj_offload === false ? 'false' : 'true'}
@@ -515,6 +514,60 @@ export function AddInstanceModal({ hostId, hostName, onClose, onCreate }: AddIns
                         Passed as <code>--reasoning-budget</code>. Use <code>-1</code> for unrestricted, <code>0</code>{' '}
                         to disable thinking. Leave blank to omit.
                       </p>
+                    </div>
+                  )}
+
+                  {/* Draft MTP speculative decoding - only for LLM mode */}
+                  {llamaCppMode === 'llm' && (
+                    <div className="md:col-span-2 rounded-md border border-nord-3 bg-nord-2 p-3">
+                      <div className="flex items-start gap-3">
+                        <input
+                          type="checkbox"
+                          id="add-spec-draft-mtp"
+                          checked={(formData as Partial<LlamaCppConfig>).spec_type === 'draft-mtp'}
+                          onChange={(e) =>
+                            setFormData((prev) => {
+                              if (e.target.checked) {
+                                return { ...prev, spec_type: 'draft-mtp', spec_draft_n_max: 2 };
+                              }
+                              const next = { ...prev } as Partial<LlamaCppConfig>;
+                              delete next.spec_type;
+                              delete next.spec_draft_n_max;
+                              return next;
+                            })
+                          }
+                          className="h-4 w-4 mt-0.5 rounded border-nord-3 bg-nord-1 text-nord-10 focus:ring-nord-10"
+                        />
+                        <div className="flex-1">
+                          <label htmlFor="add-spec-draft-mtp" className="block text-sm font-medium text-nord-4">
+                            Draft MTP speculative decoding
+                          </label>
+                          <p className="text-xs text-nord-4 mt-1">
+                            Enable faster generation for compatible MTP models. Disabled by default.
+                          </p>
+                        </div>
+                      </div>
+                      {(formData as Partial<LlamaCppConfig>).spec_type === 'draft-mtp' && (
+                        <div className="mt-3 pl-7">
+                          <label className="block text-sm font-medium text-nord-4 mb-1" htmlFor="add-spec-draft-n-max">
+                            Maximum draft tokens
+                          </label>
+                          <input
+                            type="number"
+                            id="add-spec-draft-n-max"
+                            name="spec_draft_n_max"
+                            value={(formData as Partial<LlamaCppConfig>).spec_draft_n_max ?? 2}
+                            onChange={handleChange}
+                            min="1"
+                            step="1"
+                            required
+                            className="w-full px-3 py-2 bg-nord-1 border border-nord-3 text-nord-6 rounded-md focus:ring-2 focus:ring-nord-10 focus:border-transparent"
+                          />
+                          <p className="text-xs text-nord-4 mt-1">
+                            Launches with <code>--spec-type draft-mtp --spec-draft-n-max 2</code> by default.
+                          </p>
+                        </div>
+                      )}
                     </div>
                   )}
 

--- a/src/components/EditInstanceModal.tsx
+++ b/src/components/EditInstanceModal.tsx
@@ -114,6 +114,10 @@ export function EditInstanceModal({ instance, hostId, onClose, onUpdate }: EditI
       if (!c.ot) delete c.ot;
       if (!c.mmproj) delete c.mmproj;
       if (!c.pooling) delete c.pooling;
+      if (!c.spec_type || c.model_type !== 'llm') {
+        delete c.spec_type;
+        delete c.spec_draft_n_max;
+      }
     }
 
     setLoading(true);
@@ -202,15 +206,11 @@ export function EditInstanceModal({ instance, hostId, onClose, onUpdate }: EditI
                 {/* Multimodal projector GPU offload — only when mmproj is set */}
                 {(formData as LlamaCppConfig).mmproj && (
                   <div className="md:col-span-2">
-                    <label className="block text-sm font-medium text-nord-4 mb-1">
-                      Projector GPU Offload
-                    </label>
+                    <label className="block text-sm font-medium text-nord-4 mb-1">Projector GPU Offload</label>
                     <select
                       name="mmproj_offload"
                       value={(formData as LlamaCppConfig).mmproj_offload === false ? 'false' : 'true'}
-                      onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, mmproj_offload: e.target.value === 'true' }))
-                      }
+                      onChange={(e) => setFormData((prev) => ({ ...prev, mmproj_offload: e.target.value === 'true' }))}
                       className="w-full px-3 py-2 bg-nord-2 border border-nord-3 text-nord-6 rounded-md focus:ring-2 focus:ring-nord-10 focus:border-transparent"
                     >
                       <option value="true">GPU (default)</option>
@@ -382,6 +382,60 @@ export function EditInstanceModal({ instance, hostId, onClose, onUpdate }: EditI
                     disable thinking. Leave blank to omit.
                   </p>
                 </div>
+
+                {/* Draft MTP speculative decoding - LLM only */}
+                {(formData as LlamaCppConfig).model_type === 'llm' && (
+                  <div className="md:col-span-2 rounded-md border border-nord-3 bg-nord-2 p-3">
+                    <div className="flex items-start gap-3">
+                      <input
+                        type="checkbox"
+                        id="edit-spec-draft-mtp"
+                        checked={(formData as LlamaCppConfig).spec_type === 'draft-mtp'}
+                        onChange={(e) =>
+                          setFormData((prev) => {
+                            if (e.target.checked) {
+                              return { ...prev, spec_type: 'draft-mtp', spec_draft_n_max: 2 };
+                            }
+                            const next = { ...prev } as LlamaCppConfig;
+                            delete next.spec_type;
+                            delete next.spec_draft_n_max;
+                            return next;
+                          })
+                        }
+                        className="h-4 w-4 mt-0.5 rounded border-nord-3 bg-nord-1 text-nord-10 focus:ring-nord-10"
+                      />
+                      <div className="flex-1">
+                        <label htmlFor="edit-spec-draft-mtp" className="block text-sm font-medium text-nord-4">
+                          Draft MTP speculative decoding
+                        </label>
+                        <p className="text-xs text-nord-4 mt-1">
+                          Enable faster generation for compatible MTP models. Disabled by default.
+                        </p>
+                      </div>
+                    </div>
+                    {(formData as LlamaCppConfig).spec_type === 'draft-mtp' && (
+                      <div className="mt-3 pl-7">
+                        <label className="block text-sm font-medium text-nord-4 mb-1" htmlFor="edit-spec-draft-n-max">
+                          Maximum draft tokens
+                        </label>
+                        <input
+                          type="number"
+                          id="edit-spec-draft-n-max"
+                          name="spec_draft_n_max"
+                          value={(formData as LlamaCppConfig).spec_draft_n_max ?? 2}
+                          onChange={handleChange}
+                          min="1"
+                          step="1"
+                          required
+                          className="w-full px-3 py-2 bg-nord-1 border border-nord-3 text-nord-6 rounded-md focus:ring-2 focus:ring-nord-10 focus:border-transparent"
+                        />
+                        <p className="text-xs text-nord-4 mt-1">
+                          Launches with <code>--spec-type draft-mtp --spec-draft-n-max 2</code> by default.
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )}
 
                 {/* Threads */}
                 <div>


### PR DESCRIPTION
## Summary
- Add optional Draft MTP speculative decoding controls to the llama.cpp add and edit instance modals for text generation models
- Expose `spec_type` and `spec_draft_n_max` on `LlamaCppConfig`; both fields are omitted by default
- When enabled, the UI sets `--spec-type draft-mtp` and `--spec-draft-n-max 2` by default, with an adjustable maximum draft token count

## Test plan
- [ ] Open Add Instance → llama.cpp → Text Generation and confirm Draft MTP is off by default
- [ ] Enable Draft MTP and verify the maximum draft tokens field appears with default value `2`
- [ ] Create an instance with Draft MTP enabled and confirm the saved config includes `spec_type: "draft-mtp"` and `spec_draft_n_max: 2`
- [ ] Edit an existing llama.cpp LLM instance and confirm Draft MTP state loads correctly
- [ ] Confirm Draft MTP controls are not shown for embedding or reranker modes
- [ ] Run `npm run lint && npm run build`