### PR TITLE
feat(solar-webui): add model catalog view with drawer detail (U-002)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,8 @@ import { Dashboard } from './components/Dashboard';
 import { RoutingGraph } from './components/RoutingGraph';
 import { GatewayDashboard } from './components/GatewayDashboard';
 import { EndpointsDashboard } from './components/EndpointsDashboard';
-import { Activity, Server, Key, LogOut } from 'lucide-react';
+import { ModelCatalog } from './components/ModelCatalog';
+import { Activity, Server, Key, LogOut, Database } from 'lucide-react';
 import { RoutingEventsProvider } from './context/RoutingEventsContext';
 import { useRoutingEventsContext } from './context/RoutingEventsContext';
 
@@ -58,6 +59,15 @@ function Navigation() {
           <Key size={18} />
           Endpoints
         </Link>
+        <Link
+          to="/catalog"
+          className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
+            location.pathname === '/catalog' ? 'bg-nord-10 text-nord-6 font-medium' : 'text-nord-4 hover:bg-nord-2'
+          }`}
+        >
+          <Database size={18} />
+          Catalog
+        </Link>
         <div className="ml-auto flex items-center gap-4 text-xs">
           <div className="flex items-center gap-2">
             <span className={isConnected ? 'text-nord-14' : 'text-nord-11'}>●</span>
@@ -98,6 +108,7 @@ const router = createBrowserRouter([
       { path: '/gateway', element: <GatewayDashboard /> },
       { path: '/hosts', element: <Dashboard /> },
       { path: '/endpoints', element: <EndpointsDashboard /> },
+      { path: '/catalog', element: <ModelCatalog /> },
     ],
   },
 ]);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -14,6 +14,7 @@ import {
   EndpointUsageResponse,
   PendingHost,
   PendingHostApproveRequest,
+  CatalogResponse,
 } from './types';
 
 const DEFAULT_RELATIVE_CONTROL_BASE = '/api/control';
@@ -264,6 +265,12 @@ class SolarClient {
   }): Promise<{ from: string; to: string; types: string[]; items: GatewayEventDTO[] }> {
     const response = await this.client.get('/api/gateway/events/recent', { params });
     return response.data as { from: string; to: string; types: string[]; items: GatewayEventDTO[] };
+  }
+
+  // Model catalog (D-018)
+  async getCatalogModels(params: { search?: string; limit?: number; offset?: number }): Promise<CatalogResponse> {
+    const response = await this.client.get('/api/catalog/models', { params });
+    return response.data as CatalogResponse;
   }
 
   // OpenAI Gateway

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -435,3 +435,43 @@ export interface EndpointUsageResponse {
   hours: number;
   usage: EndpointUsageStats;
 }
+
+// Model catalog (D-018: GET /api/catalog/models)
+export type CatalogEnrichmentStatus = 'ok' | 'partial' | 'unavailable';
+export type CatalogSolarStatus = 'available' | 'deployed' | 'unavailable' | 'unknown';
+
+export interface CatalogDeployedHost {
+  host_id: string;
+  host_name: string;
+  size_bytes: number;
+  path: string;
+}
+
+export interface CatalogRunningInstance {
+  host_id: string;
+  host_name: string;
+  instance_id: string;
+}
+
+export interface CatalogSolarRuntime {
+  status: CatalogSolarStatus;
+  running_instances: number;
+  deployed_hosts: CatalogDeployedHost[];
+  instances: CatalogRunningInstance[];
+}
+
+export interface CatalogModelItem {
+  name: string;
+  category: string;
+  description: string | null;
+  versions_count: number;
+  latest_version: string | null;
+  created_at: string;
+  solar: CatalogSolarRuntime;
+}
+
+export interface CatalogResponse {
+  total: number;
+  items: CatalogModelItem[];
+  meta: { enrichment: CatalogEnrichmentStatus };
+}

--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -1,0 +1,359 @@
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  AlertCircle,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  Inbox,
+  LayoutGrid,
+  RefreshCw,
+  Search,
+  Table2,
+  TriangleAlert,
+} from 'lucide-react';
+import solarClient from '@/api/client';
+import { CatalogModelItem, CatalogResponse } from '@/api/types';
+import { cn, formatDateTime } from '@/lib/utils';
+import { ModelDetail, ModelDrawer, StatusBadge } from './ModelDetail';
+
+type ViewMode = 'cards' | 'table';
+
+const VIEW_MODE_KEY = 'solar-catalog-view-mode';
+
+function readViewMode(): ViewMode {
+  try {
+    const raw = localStorage.getItem(VIEW_MODE_KEY);
+    if (raw === 'cards' || raw === 'table') return raw;
+  } catch {
+    /* ignore */
+  }
+  return 'cards';
+}
+
+export function ModelCatalog() {
+  const [data, setData] = useState<CatalogResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [limit, setLimit] = useState(25);
+  const [offset, setOffset] = useState(0);
+  const [viewMode, setViewMode] = useState<ViewMode>(readViewMode);
+  const [expandedName, setExpandedName] = useState<string | null>(null);
+  const [detailModel, setDetailModel] = useState<CatalogModelItem | null>(null);
+  const requestSeq = useRef(0);
+
+  const fetchCatalog = useCallback(async () => {
+    const seq = ++requestSeq.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await solarClient.getCatalogModels({
+        search: debouncedSearch || undefined,
+        limit,
+        offset,
+      });
+      if (seq !== requestSeq.current) return; // stale response guard
+      setData(res);
+    } catch (err: any) {
+      if (seq !== requestSeq.current) return;
+      setData(null);
+      // D-018 maps Data Repository down to 502 with an "unreachable" detail
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : 'Failed to load model catalog');
+    } finally {
+      if (seq === requestSeq.current) setLoading(false);
+    }
+  }, [debouncedSearch, limit, offset]);
+
+  useEffect(() => {
+    fetchCatalog();
+  }, [fetchCatalog]);
+
+  // Debounce the search input; a new search resets to the first page.
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      setDebouncedSearch(search);
+      setOffset(0);
+    }, 300);
+    return () => window.clearTimeout(id);
+  }, [search]);
+
+  const handleViewModeToggle = (mode: ViewMode) => {
+    setViewMode(mode);
+    localStorage.setItem(VIEW_MODE_KEY, mode);
+  };
+
+  const handleLimitChange = (value: number) => {
+    setLimit(value);
+    setOffset(0);
+  };
+
+  const toggleExpand = (name: string) => {
+    setExpandedName((prev) => (prev === name ? null : name));
+  };
+
+  const rangeStart = data && data.total > 0 ? offset + 1 : 0;
+  const rangeEnd = data ? Math.min(offset + limit, data.total) : 0;
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center justify-center" style={{ height: 'calc(100vh - 60px)' }}>
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-nord-9 mx-auto mb-4"></div>
+          <p className="text-nord-4">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-nord-0">
+      {/* Header */}
+      <header className="bg-nord-1 shadow-lg">
+        <div className="max-w-7xl mx-auto px-4 py-6 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-3xl font-bold text-nord-6">Model Catalog</h1>
+              <p className="text-sm text-nord-4 mt-1">Models in the Data Repository with Solar runtime status</p>
+            </div>
+            <div className="flex gap-2 items-center">
+              {/* Search */}
+              <div className="relative">
+                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-nord-4" />
+                <input
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search models…"
+                  className="bg-nord-1 text-nord-6 border border-nord-3 rounded pl-9 pr-3 py-2 w-64 focus:border-nord-8 outline-none"
+                />
+              </div>
+              {/* View mode toggle */}
+              <div className="flex bg-nord-3 rounded-lg p-0.5">
+                <button
+                  onClick={() => handleViewModeToggle('cards')}
+                  className={cn(
+                    'flex items-center gap-1 px-3 py-1.5 rounded-md text-sm transition-colors',
+                    viewMode === 'cards' ? 'bg-nord-10 text-nord-6' : 'text-nord-4 hover:text-nord-6',
+                  )}
+                  title="Card view"
+                >
+                  <LayoutGrid size={16} />
+                </button>
+                <button
+                  onClick={() => handleViewModeToggle('table')}
+                  className={cn(
+                    'flex items-center gap-1 px-3 py-1.5 rounded-md text-sm transition-colors',
+                    viewMode === 'table' ? 'bg-nord-10 text-nord-6' : 'text-nord-4 hover:text-nord-6',
+                  )}
+                  title="Table view"
+                >
+                  <Table2 size={16} />
+                </button>
+              </div>
+              <button
+                onClick={fetchCatalog}
+                disabled={loading}
+                className="flex items-center gap-2 px-4 py-2 bg-nord-3 text-nord-6 rounded-lg hover:bg-nord-2 transition-colors disabled:opacity-50"
+              >
+                <RefreshCw size={18} className={loading ? 'animate-spin' : ''} />
+                Refresh
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <main className="max-w-7xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
+        {error ? (
+          // Degraded state: Data Repository unreachable (502) — never render as empty catalog.
+          <div className="mb-6 p-4 bg-nord-11 bg-opacity-20 border border-nord-11 rounded-lg flex items-start gap-3">
+            <AlertCircle className="text-nord-11 flex-shrink-0" size={20} />
+            <div>
+              <h3 className="font-semibold text-nord-6">Catalog unavailable</h3>
+              <p className="text-sm text-nord-4">{error}</p>
+              <button
+                onClick={fetchCatalog}
+                className="mt-2 text-sm text-nord-8 hover:text-nord-6 flex items-center gap-1"
+              >
+                <RefreshCw size={14} /> Retry
+              </button>
+            </div>
+          </div>
+        ) : (
+          data && (
+            <>
+              {/* Enrichment banner: availability source degraded, never blocks the list */}
+              {data.meta.enrichment !== 'ok' && (
+                <div className="mb-6 p-3 bg-nord-13 bg-opacity-15 border border-nord-13 rounded text-sm text-nord-6 flex items-start gap-2">
+                  <TriangleAlert size={16} className="flex-shrink-0 mt-0.5" />
+                  <span>
+                    {data.meta.enrichment === 'partial'
+                      ? 'Availability data is partial (some hosts unreachable). Models without deployment evidence show as unknown.'
+                      : 'Host availability could not be checked. Models without running instances show as unknown.'}
+                  </span>
+                </div>
+              )}
+
+              {data.total === 0 ? (
+                /* Distinct empty states: whole catalog vs. no search match */
+                <div className="text-center py-16">
+                  {debouncedSearch ? (
+                    <>
+                      <Search size={64} className="mx-auto text-nord-3 mb-4" />
+                      <h2 className="text-2xl font-semibold text-nord-6 mb-2">
+                        No models match &quot;{debouncedSearch}&quot;
+                      </h2>
+                      <p className="text-nord-4 mb-6">Try a different search term</p>
+                      <button
+                        onClick={() => setSearch('')}
+                        className="inline-flex items-center gap-2 px-6 py-3 bg-nord-10 text-nord-6 rounded-lg hover:bg-nord-9 transition-colors"
+                      >
+                        <Search size={20} /> Clear search
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <Inbox size={64} className="mx-auto text-nord-3 mb-4" />
+                      <h2 className="text-2xl font-semibold text-nord-6 mb-2">The catalog is empty</h2>
+                      <p className="text-nord-4">No models are registered in the Data Repository</p>
+                    </>
+                  )}
+                </div>
+              ) : viewMode === 'table' ? (
+                /* Table view */
+                <div className="bg-nord-1 border border-nord-3 rounded overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-nord-3 text-left text-xs text-nord-4">
+                        <th className="px-4 py-3 font-medium">Status</th>
+                        <th className="px-4 py-3 font-medium">Model</th>
+                        <th className="px-4 py-3 font-medium">Versions</th>
+                        <th className="px-4 py-3 font-medium">Latest</th>
+                        <th className="px-4 py-3 font-medium">Running</th>
+                        <th className="px-4 py-3 font-medium">Deployed hosts</th>
+                        <th className="px-4 py-3 font-medium">Created</th>
+                        <th className="px-4 py-3"></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.items.map((model) => {
+                        const expanded = expandedName === model.name;
+                        return (
+                          <Fragment key={model.name}>
+                            <tr
+                              onClick={() => toggleExpand(model.name)}
+                              className="border-b border-nord-3 hover:bg-nord-2/50 cursor-pointer"
+                            >
+                              <td className="px-4 py-3">
+                                <StatusBadge status={model.solar.status} />
+                              </td>
+                              <td className="px-4 py-3">
+                                <div className="font-medium text-nord-6 break-all">{model.name}</div>
+                                <div className="text-xs text-nord-4">{model.category}</div>
+                              </td>
+                              <td className="px-4 py-3 text-nord-6">{model.versions_count}</td>
+                              <td className="px-4 py-3 text-nord-6">{model.latest_version ?? '—'}</td>
+                              <td className="px-4 py-3 text-nord-6">{model.solar.running_instances}</td>
+                              <td className="px-4 py-3 text-nord-6">{model.solar.deployed_hosts.length}</td>
+                              <td className="px-4 py-3 text-nord-4">{formatDateTime(model.created_at)}</td>
+                              <td className="px-4 py-3 text-nord-4">
+                                {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                              </td>
+                            </tr>
+                            {expanded && (
+                              <tr className="border-b border-nord-3">
+                                <td colSpan={8} className="p-0">
+                                  <div className="bg-nord-2/50 p-4 sm:p-6">
+                                    <ModelDetail model={model} />
+                                  </div>
+                                </td>
+                              </tr>
+                            )}
+                          </Fragment>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                /* Cards view */
+                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+                  {data.items.map((model) => (
+                    <div
+                      key={model.name}
+                      onClick={() => setDetailModel(model)}
+                      className="bg-nord-1 border border-nord-3 rounded p-4 cursor-pointer hover:bg-nord-2/50 hover:border-nord-8/60 transition-colors"
+                    >
+                      <div className="flex items-center justify-between mb-2">
+                        <StatusBadge status={model.solar.status} />
+                        <div className="flex items-center gap-2">
+                          {model.latest_version && (
+                            <span className="bg-nord-2 text-nord-4 rounded px-2 py-0.5 text-xs">
+                              {model.latest_version}
+                            </span>
+                          )}
+                          <ChevronRight size={16} className="text-nord-4" />
+                        </div>
+                      </div>
+                      <h3 className="font-medium text-nord-6 break-all">{model.name}</h3>
+                      <p className="text-xs text-nord-4 mt-0.5">{model.category}</p>
+                      {model.description && (
+                        <p className="text-sm text-nord-4 mt-2 line-clamp-2">{model.description}</p>
+                      )}
+                      <p className="text-xs text-nord-4 mt-2">
+                        {model.versions_count} version{model.versions_count === 1 ? '' : 's'} •{' '}
+                        {model.solar.running_instances} running • {model.solar.deployed_hosts.length} host
+                        {model.solar.deployed_hosts.length === 1 ? '' : 's'}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Pagination + page size */}
+              <div className="mt-4 flex items-center justify-between text-sm text-nord-4">
+                <span>
+                  {rangeStart}–{rangeEnd} of {data.total}
+                </span>
+                <div className="flex gap-2 items-center">
+                  <span className="mr-1 text-xs">Show</span>
+                  <select
+                    value={limit}
+                    onChange={(e) => handleLimitChange(Number(e.target.value))}
+                    className="bg-nord-2 text-nord-6 border border-nord-3 rounded px-2 py-1"
+                  >
+                    {[10, 25, 50, 100].map((n) => (
+                      <option key={n} value={n}>
+                        {n}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    onClick={() => setOffset((prev) => Math.max(0, prev - limit))}
+                    disabled={offset === 0}
+                    className="px-3 py-1 rounded bg-nord-3 text-nord-6 hover:bg-nord-2 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1"
+                  >
+                    <ChevronLeft size={16} /> Prev
+                  </button>
+                  <button
+                    onClick={() => setOffset((prev) => prev + limit)}
+                    disabled={data.total === 0 || offset + limit >= data.total}
+                    className="px-3 py-1 rounded bg-nord-3 text-nord-6 hover:bg-nord-2 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1"
+                  >
+                    Next <ChevronRight size={16} />
+                  </button>
+                </div>
+              </div>
+            </>
+          )
+        )}
+      </main>
+
+      {/* Detail drawer — cards view opens this instead of expanding in place */}
+      <ModelDrawer model={detailModel} onClose={() => setDetailModel(null)} />
+    </div>
+  );
+}

--- a/src/components/ModelDetail.tsx
+++ b/src/components/ModelDetail.tsx
@@ -1,0 +1,187 @@
+import { Fragment, useEffect, type ReactNode } from 'react';
+import { Rocket, X } from 'lucide-react';
+import { CatalogDeployedHost, CatalogModelItem, CatalogSolarStatus } from '@/api/types';
+import { cn, formatBytes, formatDateTime, getCatalogStatusColor } from '@/lib/utils';
+
+const STATUS_TOOLTIPS: Record<CatalogSolarStatus, string> = {
+  available: 'At least one instance running',
+  deployed: 'Files present on hosts, no instance running',
+  unavailable: 'Not deployed',
+  unknown: 'Availability source unreachable — absence cannot be confirmed',
+};
+
+export function StatusBadge({ status }: { status: CatalogSolarStatus }) {
+  return (
+    <span
+      title={STATUS_TOOLTIPS[status] ?? status}
+      className={cn('px-2 py-0.5 rounded text-xs font-medium', getCatalogStatusColor(status))}
+    >
+      {status}
+    </span>
+  );
+}
+
+function StatBlock({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs text-nord-4 uppercase tracking-wide">{label}</dt>
+      <dd className="mt-1 text-sm font-medium text-nord-6">{children}</dd>
+    </div>
+  );
+}
+
+export function ModelDetail({ model }: { model: CatalogModelItem }) {
+  // D-018 can list the same host once per model version path present on it
+  // (verified in live dev data: damcpaiops02 appears for both v1 and v2).
+  // Group by host name but keep every path — do not dedupe silently.
+  const deployedByHost = new Map<string, CatalogDeployedHost[]>();
+  for (const entry of model.solar.deployed_hosts) {
+    const entries = deployedByHost.get(entry.host_name) ?? [];
+    entries.push(entry);
+    deployedByHost.set(entry.host_name, entries);
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Stat strip — one glance at the essentials, no label/value pair walls */}
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-4 sm:grid-cols-3 lg:grid-cols-5">
+        <StatBlock label="Category">{model.category}</StatBlock>
+        <StatBlock label="Versions">{model.versions_count}</StatBlock>
+        <StatBlock label="Latest version">{model.latest_version ?? '—'}</StatBlock>
+        <StatBlock label="Created">{formatDateTime(model.created_at)}</StatBlock>
+        <StatBlock label="Status">
+          <StatusBadge status={model.solar.status} />
+        </StatBlock>
+      </dl>
+
+      {model.description && <p className="text-sm text-nord-4">{model.description}</p>}
+
+      {/* Deployment */}
+      <section>
+        <h4 className="text-sm font-semibold text-nord-6 uppercase tracking-wide">Deployment</h4>
+        <div className="mt-3 space-y-4">
+          <div>
+            <h5 className="text-xs text-nord-4">Running instances</h5>
+            {model.solar.instances.length > 0 ? (
+              <ul className="mt-1.5 flex flex-wrap gap-2">
+                {model.solar.instances.map((instance) => (
+                  <li
+                    key={instance.instance_id}
+                    className="inline-flex items-center gap-1.5 bg-nord-2 rounded-md px-2 py-1 text-xs"
+                  >
+                    <span className="font-medium text-nord-6">{instance.host_name}</span>
+                    <span className="font-mono text-nord-4">{instance.instance_id}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-1 text-sm text-nord-4">No running instances</p>
+            )}
+          </div>
+
+          <div>
+            <h5 className="text-xs text-nord-4">Deployed hosts</h5>
+            {deployedByHost.size > 0 ? (
+              <div className="mt-1.5 overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-nord-3 text-left text-xs text-nord-4">
+                      <th className="py-2 pr-4 font-medium">Host</th>
+                      <th className="py-2 pr-4 font-medium whitespace-nowrap">Size</th>
+                      <th className="py-2 font-medium">Path</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[...deployedByHost.entries()].map(([hostName, entries]) => (
+                      <Fragment key={hostName}>
+                        <tr className="align-top">
+                          <td rowSpan={entries.length} className="py-2 pr-4 font-medium text-nord-6">
+                            {hostName}
+                          </td>
+                          <td className="py-2 pr-4 whitespace-nowrap text-nord-4">
+                            {formatBytes(entries[0].size_bytes)}
+                          </td>
+                          <td className="py-2 font-mono text-xs text-nord-4 break-all">{entries[0].path}</td>
+                        </tr>
+                        {entries.slice(1).map((entry) => (
+                          <tr key={entry.path} className="align-top">
+                            <td className="py-2 pr-4 whitespace-nowrap text-nord-4">{formatBytes(entry.size_bytes)}</td>
+                            <td className="py-2 font-mono text-xs text-nord-4 break-all">{entry.path}</td>
+                          </tr>
+                        ))}
+                      </Fragment>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : model.solar.status === 'unknown' ? (
+              <p className="mt-1 text-sm text-nord-13">Availability could not be verified (hosts unreachable)</p>
+            ) : (
+              <p className="mt-1 text-sm text-nord-4">No deployed hosts</p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* Deploy affordance — disabled until U-003 (intent submission UI) lands */}
+      <div className="flex justify-end border-t border-nord-3 pt-3">
+        <button
+          disabled
+          title="Model deployment UI ships with U-003 (intent submission)"
+          className="px-3 py-1.5 rounded bg-nord-3 text-nord-4 text-sm cursor-not-allowed opacity-60"
+        >
+          <Rocket size={14} className="inline mr-1" /> Deploy
+        </button>
+      </div>
+      {/* U-003 handoff: when /intents lands, replace the disabled button with a real
+          useNavigate call:
+          navigate(
+            `/intents?alias=${encodeURIComponent(model.name)}&model_source=${encodeURIComponent(
+              `repo://${model.name}:${model.latest_version ?? ''}`,
+            )}`,
+          ) */}
+    </div>
+  );
+}
+
+/**
+ * Slide-over detail panel used by the cards view. Renders nothing when
+ * `model` is null so the parent can keep it mounted and drive open/close
+ * purely through state.
+ */
+export function ModelDrawer({ model, onClose }: { model: CatalogModelItem | null; onClose: () => void }) {
+  useEffect(() => {
+    if (!model) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [model, onClose]);
+
+  if (!model) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/70 animate-[fade-in_150ms_ease-out]" onClick={onClose} />
+      <aside className="absolute right-0 top-0 h-full w-full max-w-md bg-nord-1 border-l border-nord-3 shadow-2xl flex flex-col animate-[slide-in-right_200ms_ease-out]">
+        <header className="flex items-start justify-between gap-4 p-4 sm:p-5 border-b border-nord-3">
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold text-nord-6 break-all">{model.name}</h2>
+            <p className="text-xs text-nord-4 mt-0.5">{model.category}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded hover:bg-nord-2 text-nord-4 hover:text-nord-6 transition-colors"
+            title="Close"
+          >
+            <X size={18} />
+          </button>
+        </header>
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+          <ModelDetail model={model} />
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -37,16 +37,34 @@
   height: 8px;
 }
 
+/* Drawer / overlay entrance animations (transform + opacity only) */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slide-in-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
 ::-webkit-scrollbar-track {
-  background: #3B4252; /* nord1 */
+  background: #3b4252; /* nord1 */
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #4C566A; /* nord3 */
+  background: #4c566a; /* nord3 */
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #5E81AC; /* nord10 */
+  background: #5e81ac; /* nord10 */
 }
-

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -133,3 +133,25 @@ export function formatTokenCount(count: number | undefined | null): string {
   const rounded = count.toFixed(1);
   return rounded.replace(/\.0$/, '');
 }
+
+export function formatBytes(bytes: number | undefined | null): string {
+  if (bytes === undefined || bytes === null || isNaN(bytes)) return '—';
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, i);
+  return `${value.toFixed(value >= 100 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+export function getCatalogStatusColor(status: string): string {
+  switch (status) {
+    case 'available':
+      return 'text-nord-6 bg-nord-14'; // green — running
+    case 'deployed':
+      return 'text-nord-6 bg-nord-10'; // blue — on hosts, not running
+    case 'unknown':
+      return 'text-nord-0 bg-nord-13'; // yellow — availability unknown
+    default:
+      return 'text-nord-4 bg-nord-3'; // unavailable / anything else — gray
+  }
+}


### PR DESCRIPTION
## Description
Adds the model catalog page (`/catalog`) to Solar WebUI, consuming D-018's `GET /api/catalog/models` through the existing `/api/control` proxy — the Data Repository stays the metadata authority and Solar Control is the only API the WebUI talks to. Operators can now answer "what models do we have, which versions, and where are they running?" from the operations UI.

## Changes
- New `Catalog` route and top-nav entry alongside Routing / Gateway / Hosts & Instances / Endpoints
- Typed API client method for D-018's `GET /api/catalog/models` plus catalog types (model summary, version summary, availability/deployment enrichment) in `src/api/types.ts`
- `ModelCatalog` page: cards/table view-mode toggle (persisted in localStorage), debounced search, pagination (`limit`/`offset` + `total` from response), refresh
- `ModelDetail` component: stat strip (category, versions, latest version, created, status badge), running instance chips, deployed-hosts table (Host | Size | Path, host name rowspan-merged across version paths)
- Cards view opens a slide-over detail drawer (Escape/overlay close, 200ms slide-in animation); table view expands the detail inline
- Explicit degraded states: Data Repository unreachable → error banner (never an empty catalog), partial/unavailable enrichment → warning banner, distinct empty states (empty catalog vs. no search match)
- Disabled "Deploy" affordance per model, pre-wired for the U-003 intent form handoff (`repo://{name}:{version}`) — no parallel deployment path
- Drawer/fade keyframes in `src/index.css` (transform + opacity only)

## Related Issues
Closes #22 (U-002: Add model catalog view to Solar WebUI)
