### PR TITLE
feat(solar-webui): implement resource utilization dashboard (U-004)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider, Navigate, Link, useLocation, Outlet } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, Navigate, Outlet } from 'react-router-dom';
 import { Dashboard } from './components/Dashboard';
 import { RoutingGraph } from './components/RoutingGraph';
 import { GatewayDashboard } from './components/GatewayDashboard';
@@ -6,100 +6,9 @@ import { EndpointsDashboard } from './components/EndpointsDashboard';
 import { ModelCatalog } from './components/ModelCatalog';
 import { IntentsPage } from './components/IntentsPage';
 import { IntentDetail } from './components/IntentDetail';
-import { Activity, Server, Key, LogOut, Database, Target } from 'lucide-react';
+import { Navigation } from './components/Navigation';
+import { ResourcesPage } from './components/ResourcesPage';
 import { RoutingEventsProvider } from './context/RoutingEventsContext';
-import { useRoutingEventsContext } from './context/RoutingEventsContext';
-
-function Navigation() {
-  const location = useLocation();
-  let isConnected = false;
-  try {
-    const ctx = useRoutingEventsContext();
-    isConnected = ctx.routingConnected;
-  } catch {}
-
-  return (
-    <nav className="bg-nord-1 border-b border-nord-3 px-6 py-3">
-      <div className="flex items-center gap-6">
-        <div className="flex items-center gap-2 mr-8">
-          <Activity className="text-nord-8" size={24} />
-          <span className="font-bold text-xl text-nord-6">Solar</span>
-        </div>
-        <Link
-          to="/routing"
-          className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-            location.pathname === '/routing' ? 'bg-nord-10 text-nord-6 font-medium' : 'text-nord-4 hover:bg-nord-2'
-          }`}
-        >
-          <Activity size={18} />
-          Routing
-        </Link>
-        <Link
-          to="/gateway"
-          className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-            location.pathname === '/gateway' ? 'bg-nord-10 text-nord-6 font-medium' : 'text-nord-4 hover:bg-nord-2'
-          }`}
-        >
-          <Activity size={18} />
-          Gateway
-        </Link>
-        <Link
-          to="/hosts"
-          className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-            location.pathname === '/hosts' ? 'bg-nord-10 text-nord-6 font-medium' : 'text-nord-4 hover:bg-nord-2'
-          }`}
-        >
-          <Server size={18} />
-          Hosts & Instances
-        </Link>
-        <Link
-          to="/intents"
-          className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-            location.pathname.startsWith('/intents')
-              ? 'bg-nord-10 text-nord-6 font-medium'
-              : 'text-nord-4 hover:bg-nord-2'
-          }`}
-        >
-          <Target size={18} />
-          Intents
-        </Link>
-        <Link
-          to="/endpoints"
-          className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-            location.pathname === '/endpoints' ? 'bg-nord-10 text-nord-6 font-medium' : 'text-nord-4 hover:bg-nord-2'
-          }`}
-        >
-          <Key size={18} />
-          Endpoints
-        </Link>
-        <Link
-          to="/catalog"
-          className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-            location.pathname === '/catalog' ? 'bg-nord-10 text-nord-6 font-medium' : 'text-nord-4 hover:bg-nord-2'
-          }`}
-        >
-          <Database size={18} />
-          Catalog
-        </Link>
-        <div className="ml-auto flex items-center gap-4 text-xs">
-          <div className="flex items-center gap-2">
-            <span className={isConnected ? 'text-nord-14' : 'text-nord-11'}>●</span>
-            <span className="text-nord-4">Event Stream</span>
-          </div>
-          <form method="post" action="/auth/logout">
-            <button
-              type="submit"
-              className="flex items-center gap-1 rounded-md px-2 py-1 text-nord-4 transition-colors hover:bg-nord-2 hover:text-nord-6"
-            >
-              <LogOut size={14} />
-              Logout
-            </button>
-          </form>
-        </div>
-      </div>
-    </nav>
-  );
-}
 
 function Layout() {
   return (
@@ -122,6 +31,7 @@ const router = createBrowserRouter([
       { path: '/hosts', element: <Dashboard /> },
       { path: '/intents', element: <IntentsPage /> },
       { path: '/intents/:id', element: <IntentDetail /> },
+      { path: '/resources', element: <ResourcesPage /> },
       { path: '/endpoints', element: <EndpointsDashboard /> },
       { path: '/catalog', element: <ModelCatalog /> },
     ],

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -18,6 +18,8 @@ import {
   Intent,
   IntentCreateRequest,
   IntentDeletedResponse,
+  AggregatedResourceResponse,
+  ResourcesQueryParams,
 } from './types';
 
 const DEFAULT_RELATIVE_CONTROL_BASE = '/api/control';
@@ -295,6 +297,12 @@ class SolarClient {
   async deleteIntent(id: string, orphan = false): Promise<IntentDeletedResponse> {
     const response = await this.client.delete(`/api/intents/${id}`, { params: { orphan } });
     return response.data as IntentDeletedResponse;
+  }
+
+  // Resource utilization (U-004, S-035)
+  async getResources(params?: ResourcesQueryParams): Promise<AggregatedResourceResponse> {
+    const response = await this.client.get('/api/resources', { params });
+    return response.data as AggregatedResourceResponse;
   }
 
   // OpenAI Gateway

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -602,3 +602,98 @@ export interface IntentDeletedResponse {
   phase: IntentPhase;
   message: string;
 }
+
+// ─── Resource utilization (U-004, GET /api/resources — S-035 + PR #62) ───
+
+export interface ActiveJobSummary {
+  job_id: string;
+  submission_id?: string | null;
+  name?: string | null;
+  status: string;
+  current_step_name?: string | null;
+  current_step_index?: number | null;
+  last_step_name?: string | null;
+  last_step_index?: number | null;
+  pipeline?: string[];
+  resource_hints?: Record<string, unknown>;
+  started_at?: string | null;
+  completed_at?: string | null;
+  error_message?: string | null;
+}
+
+export interface HostInstanceSummary {
+  id: string;
+  alias?: string | null;
+  status?: string | null;
+  backend_type?: string | null;
+  port?: number | null;
+  supported_endpoints?: string[];
+}
+
+export interface HostReservationSummary {
+  id: string;
+  job_id: string; // owner — attribution for the reserved segment
+  workload_type: string;
+  status: string; // 'pending' | 'running'
+  vram_gb?: number;
+  ram_gb?: number;
+  disk_gb?: number | null;
+  actual_vram_gb?: number | null; // set only for running reservations
+  actual_ram_gb?: number | null;
+  actual_disk_gb?: number | null;
+  expires_at?: string | null;
+}
+
+export interface HostResourceSnapshot {
+  host_id: string;
+  host_name: string;
+  url: string;
+  status: HostStatus;
+  roles: string[];
+  gpu_type?: string | null;
+  version?: string | null;
+  reachable: boolean;
+  error?: string | null;
+  vram_total_gb?: number | null;
+  vram_system_used_gb?: number | null;
+  vram_reserved_headroom_gb?: number | null;
+  vram_reported_used_gb?: number | null;
+  vram_available_gb?: number | null;
+  ram_total_gb?: number | null;
+  ram_system_used_gb?: number | null;
+  ram_reserved_headroom_gb?: number | null;
+  ram_reported_used_gb?: number | null;
+  ram_available_gb?: number | null;
+  disk_total_gb?: number | null;
+  disk_system_used_gb?: number | null;
+  disk_reserved_headroom_gb?: number | null;
+  disk_reported_used_gb?: number | null;
+  disk_available_gb?: number | null;
+  instance_count: number;
+  running_instance_count: number;
+  instances: HostInstanceSummary[]; // PR #62 — aliases included
+  active_jobs: ActiveJobSummary[];
+  reservation_count: number;
+  reservation_vram_total_gb: number;
+  reservation_ram_total_gb: number;
+  reservation_disk_total_gb: number;
+  reservations: HostReservationSummary[]; // PR #62 — per-reservation details
+  vram_training_used_gb: number; // PR #62 — Σ actuals of running reservations
+  ram_training_used_gb: number;
+  disk_training_used_gb: number;
+  snapshot_timestamp?: string | null;
+}
+
+export interface AggregatedResourceResponse {
+  hosts: HostResourceSnapshot[];
+  total_hosts: number;
+  reachable_hosts: number;
+  unreachable_hosts: number;
+}
+
+export interface ResourcesQueryParams {
+  role?: string;
+  gpu_type?: string;
+  min_available_vram_gb?: number;
+  min_available_ram_gb?: number;
+}

--- a/src/components/HostCard.tsx
+++ b/src/components/HostCard.tsx
@@ -1,6 +1,16 @@
 import { useState, useMemo, useCallback } from 'react';
 import { Instance, InstanceConfig, MemoryInfo, getModelCategory, ModelCategory } from '@/api/types';
-import { cn, getStatusColor, formatDate, getMemoryColor, formatMemoryUsage, formatDiskUsage } from '@/lib/utils';
+import {
+  cn,
+  getStatusColor,
+  formatDate,
+  getMemoryColor,
+  formatMemoryUsage,
+  formatDiskUsage,
+  getGpuTypeLabel,
+  getGpuTypeBadgeClass,
+  getRoleBadgeClass,
+} from '@/lib/utils';
 import { InstanceCard } from './InstanceCard';
 import { AddInstanceModal } from './AddInstanceModal';
 import {
@@ -71,43 +81,6 @@ const CategoryIcon = ({ category, size = 14 }: { category: ModelCategory; size?:
       return <Search size={size} />;
     default:
       return <Brain size={size} />;
-  }
-};
-
-const getGpuTypeLabel = (gpuType: string): string => {
-  switch (gpuType) {
-    case 'nvidia_cuda':
-      return 'NVIDIA CUDA';
-    case 'apple_mps':
-      return 'Apple MPS';
-    case 'cpu':
-      return 'CPU';
-    default:
-      return gpuType;
-  }
-};
-
-const getGpuTypeBadgeClass = (gpuType: string): string => {
-  switch (gpuType) {
-    case 'nvidia_cuda':
-      return 'bg-nord-14 text-nord-6';
-    case 'apple_mps':
-      return 'bg-nord-15 text-nord-6';
-    case 'cpu':
-      return 'bg-nord-3 text-nord-6';
-    default:
-      return 'bg-nord-3 text-nord-6';
-  }
-};
-
-const getRoleBadgeClass = (role: string): string => {
-  switch (role) {
-    case 'inference':
-      return 'bg-nord-6 bg-opacity-20 text-nord-6';
-    case 'training':
-      return 'bg-nord-15 text-nord-6';
-    default:
-      return 'bg-nord-6 bg-opacity-15 text-nord-6';
   }
 };
 

--- a/src/components/HostResourceCard.tsx
+++ b/src/components/HostResourceCard.tsx
@@ -1,0 +1,288 @@
+import { useState } from 'react';
+import { AlertTriangle, ChevronDown, ChevronUp, Cpu, HardDrive, Layers, MemoryStick, Server } from 'lucide-react';
+import { ActiveJobSummary, HostResourceSnapshot } from '@/api/types';
+import { cn, getStatusColor, getGpuTypeLabel, getGpuTypeBadgeClass, getRoleBadgeClass } from '@/lib/utils';
+import { ResourceBar, ResourceBarSegment } from './ResourceBar';
+
+const DIM_LABELS: Record<'vram' | 'ram' | 'disk', string> = {
+  vram: 'VRAM',
+  ram: 'RAM',
+  disk: 'Disk',
+};
+
+const DIM_ICONS: Record<'vram' | 'ram' | 'disk', React.ReactNode> = {
+  vram: <Cpu size={12} />,
+  ram: <MemoryStick size={12} />,
+  disk: <HardDrive size={12} />,
+};
+
+const fmtGb = (value: number | null | undefined): string => (value == null ? '—' : `${value.toFixed(1)} GB`);
+
+/** Build the [inference, training?, reserved?] segments for one dimension. */
+function buildSegments(snapshot: HostResourceSnapshot, dim: 'vram' | 'ram' | 'disk'): ResourceBarSegment[] {
+  const systemUsed = snapshot[`${dim}_system_used_gb`] ?? 0;
+  const training = snapshot[`${dim}_training_used_gb`] ?? 0;
+  const reserved = snapshot[`${dim}_reserved_headroom_gb`] ?? 0;
+
+  const segments: ResourceBarSegment[] = [
+    {
+      key: 'inference',
+      label: `Inference (${snapshot.running_instance_count} instance${snapshot.running_instance_count === 1 ? '' : 's'})`,
+      gb: Math.max(0, systemUsed - training),
+      className: 'bg-nord-10',
+    },
+  ];
+  if (training > 0) {
+    segments.push({
+      key: 'training',
+      label: `Training (${snapshot.active_jobs.length} job step${snapshot.active_jobs.length === 1 ? '' : 's'})`,
+      gb: training,
+      className: 'bg-nord-15',
+    });
+  }
+  if (reserved > 0) {
+    segments.push({
+      key: 'reserved',
+      label: `Reserved (${snapshot.reservation_count} reservation${snapshot.reservation_count === 1 ? '' : 's'})`,
+      gb: reserved,
+      className: 'bg-nord-13',
+    });
+  }
+  return segments;
+}
+
+/**
+ * Active training job steps, rendered as a compact list.
+ * Shared rendering path — U-001 reuses this for host-card training indicators.
+ */
+function ActiveJobsList({ jobs }: { jobs: ActiveJobSummary[] }) {
+  if (jobs.length === 0) {
+    return <p className="text-sm text-nord-4">No active job steps</p>;
+  }
+  return (
+    <ul className="space-y-1.5">
+      {jobs.map((job) => {
+        const terminal = job.status === 'completed' || job.status === 'failed';
+        const stepName = terminal ? job.last_step_name : job.current_step_name;
+        return (
+          <li key={job.job_id} className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+            <span
+              className="font-mono text-xs text-nord-6 break-all"
+              title={job.submission_id ? `submission: ${job.submission_id}` : undefined}
+            >
+              {job.job_id}
+            </span>
+            {job.name && <span className="font-medium text-nord-6">{job.name}</span>}
+            {stepName && (
+              <span className="text-xs text-nord-4">
+                step: {stepName}
+                {job.current_step_index != null ? ` (${job.current_step_index})` : ''}
+              </span>
+            )}
+            <span className={cn('px-2 py-0.5 rounded-full text-xs font-medium', getStatusColor(job.status))}>
+              {job.status}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function HostResourceCard({ snapshot }: { snapshot: HostResourceSnapshot }) {
+  const [expanded, setExpanded] = useState(false);
+  const unreachable = !snapshot.reachable;
+
+  return (
+    <div
+      className={cn(
+        'bg-nord-1 border rounded-lg p-4 space-y-3',
+        unreachable ? 'border-nord-11/40 opacity-70' : 'border-nord-3',
+      )}
+    >
+      {/* Header */}
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Server size={18} className="text-nord-8 shrink-0" />
+          <h3 className="text-nord-6 font-semibold truncate" title={snapshot.url}>
+            {snapshot.host_name}
+          </h3>
+          {snapshot.version && <span className="text-xs text-nord-4 shrink-0">v{snapshot.version}</span>}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {snapshot.roles.map((role) => (
+            <span key={role} className={cn('px-2 py-1 rounded-full text-xs font-medium', getRoleBadgeClass(role))}>
+              {role}
+            </span>
+          ))}
+          {snapshot.gpu_type && (
+            <span
+              className={cn('px-2 py-1 rounded-full text-xs font-medium', getGpuTypeBadgeClass(snapshot.gpu_type))}
+              title={`Acceleration: ${getGpuTypeLabel(snapshot.gpu_type)}`}
+            >
+              {getGpuTypeLabel(snapshot.gpu_type)}
+            </span>
+          )}
+          <span className={cn('px-2 py-1 rounded-full text-xs font-medium', getStatusColor(snapshot.status))}>
+            {snapshot.status}
+          </span>
+          {unreachable && (
+            <span
+              className="px-2 py-1 rounded-full text-xs font-medium bg-nord-11 bg-opacity-30 text-nord-11 flex items-center gap-1"
+              title={snapshot.error ?? undefined}
+            >
+              <AlertTriangle size={12} />
+              unreachable
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Per-dimension segmented bars */}
+      {(['vram', 'ram', 'disk'] as const).map((dim) => {
+        const total = snapshot[`${dim}_total_gb`] ?? null;
+        const available = snapshot[`${dim}_available_gb`] ?? null;
+        const noData = total == null;
+        return (
+          <div key={dim}>
+            <ResourceBar
+              dimLabel={DIM_LABELS[dim]}
+              icon={DIM_ICONS[dim]}
+              totalGb={total}
+              segments={buildSegments(snapshot, dim)}
+              availableGb={available}
+              unavailable={unreachable || noData}
+            />
+            {noData && !unreachable && (
+              <div className="mt-1">
+                <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-nord-2 text-nord-4">
+                  no live data
+                </span>
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {/* Workloads panel */}
+      <div className="border-t border-nord-3 pt-3">
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="flex w-full items-center justify-between gap-2 text-sm text-nord-6 font-medium"
+        >
+          <span className="flex items-center gap-2">
+            <Layers size={14} className="text-nord-4" />
+            Workloads
+          </span>
+          <span className="flex items-center gap-2">
+            <span className="text-xs font-normal text-nord-4">
+              {snapshot.running_instance_count} instance{snapshot.running_instance_count === 1 ? '' : 's'} ·{' '}
+              {snapshot.active_jobs.length} job{snapshot.active_jobs.length === 1 ? '' : 's'} ·{' '}
+              {snapshot.reservation_count} reservation{snapshot.reservation_count === 1 ? '' : 's'}
+            </span>
+            {expanded ? <ChevronUp size={16} className="shrink-0" /> : <ChevronDown size={16} className="shrink-0" />}
+          </span>
+        </button>
+
+        {expanded && (
+          <div className="mt-3 space-y-4">
+            {unreachable ? (
+              <p className="flex items-center gap-2 text-sm text-nord-11">
+                <AlertTriangle size={14} />
+                {snapshot.error ?? 'Host unreachable'}
+              </p>
+            ) : (
+              <>
+                {/* Instances */}
+                <div>
+                  <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-nord-4">
+                    Instances ({snapshot.instance_count})
+                  </h4>
+                  {snapshot.instances.length > 0 ? (
+                    <ul className="space-y-1.5">
+                      {snapshot.instances.map((inst) => (
+                        <li key={inst.id} className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+                          <span className="min-w-0 font-medium text-nord-6">{inst.alias || inst.id}</span>
+                          {inst.status && (
+                            <span
+                              className={cn(
+                                'px-2 py-0.5 rounded-full text-xs font-medium',
+                                getStatusColor(inst.status),
+                              )}
+                            >
+                              {inst.status}
+                            </span>
+                          )}
+                          {inst.backend_type && <span className="text-xs text-nord-4">{inst.backend_type}</span>}
+                          {inst.port != null && <span className="font-mono text-xs text-nord-4">:{inst.port}</span>}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : snapshot.instance_count > 0 ? (
+                    <p className="text-sm text-nord-4">
+                      {snapshot.instance_count} instance{snapshot.instance_count === 1 ? '' : 's'} — details unavailable
+                    </p>
+                  ) : (
+                    <p className="text-sm text-nord-4">No instances</p>
+                  )}
+                </div>
+
+                {/* Training jobs */}
+                <div>
+                  <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-nord-4">
+                    Training Jobs ({snapshot.active_jobs.length})
+                  </h4>
+                  <ActiveJobsList jobs={snapshot.active_jobs} />
+                </div>
+
+                {/* Reservations */}
+                <div>
+                  <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-nord-4">
+                    Reservations ({snapshot.reservation_count})
+                  </h4>
+                  {snapshot.reservations.length > 0 ? (
+                    <ul className="space-y-1.5">
+                      {snapshot.reservations.map((res) => (
+                        <li key={res.id} className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+                          <span className="font-mono text-xs text-nord-6 break-all" title={res.id}>
+                            {res.job_id}
+                          </span>
+                          <span
+                            className={cn(
+                              'px-2 py-0.5 rounded-full text-xs font-medium',
+                              res.status === 'pending' ? 'text-nord-0 bg-nord-13' : getStatusColor(res.status),
+                            )}
+                          >
+                            {res.status}
+                          </span>
+                          <span className="text-xs text-nord-4">
+                            req {fmtGb(res.vram_gb)} VRAM · {fmtGb(res.ram_gb)} RAM · {fmtGb(res.disk_gb)} disk
+                          </span>
+                          {res.status === 'running' && (
+                            <span className="text-xs text-nord-4">
+                              actual {fmtGb(res.actual_vram_gb)} VRAM · {fmtGb(res.actual_ram_gb)} RAM ·{' '}
+                              {fmtGb(res.actual_disk_gb)} disk
+                            </span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-sm text-nord-4">No reservations</p>
+                  )}
+                  {snapshot.reservation_count > 0 && (
+                    <p className="mt-2 text-xs text-nord-4">
+                      Totals: {snapshot.reservation_vram_total_gb.toFixed(1)} VRAM ·{' '}
+                      {snapshot.reservation_ram_total_gb.toFixed(1)} RAM ·{' '}
+                      {snapshot.reservation_disk_total_gb.toFixed(1)} disk
+                    </p>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,102 @@
+import { Link, useLocation } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { Activity, Server, Target, Gauge, Key, Database, LogOut } from 'lucide-react';
+import { useRoutingEventsContext } from '@/context/RoutingEventsContext';
+
+function NavItem({ to, icon, label, active }: { to: string; icon: ReactNode; label: string; active: boolean }) {
+  return (
+    <Link
+      to={to}
+      className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors whitespace-nowrap shrink-0 ${
+        active ? 'bg-nord-10 text-nord-6 font-medium' : 'text-nord-4 hover:bg-nord-2'
+      }`}
+    >
+      {icon}
+      {label}
+    </Link>
+  );
+}
+
+export function Navigation() {
+  const location = useLocation();
+  let isConnected = false;
+  try {
+    const ctx = useRoutingEventsContext();
+    isConnected = ctx.routingConnected;
+  } catch {}
+
+  return (
+    <nav className="bg-nord-1 border-b border-nord-3 px-6 py-3">
+      <div className="flex items-center gap-6 min-w-0">
+        {/* Logo — pinned */}
+        <div className="flex items-center gap-2 mr-8 shrink-0">
+          <Activity className="text-nord-8" size={24} />
+          <span className="font-bold text-xl text-nord-6">Solar</span>
+        </div>
+
+        {/* Link strip — scrolls internally on narrow viewports */}
+        <div className="flex-1 min-w-0 flex items-center gap-1 overflow-x-auto no-scrollbar">
+          <NavItem
+            to="/routing"
+            icon={<Activity size={18} />}
+            label="Routing"
+            active={location.pathname === '/routing'}
+          />
+          <NavItem
+            to="/gateway"
+            icon={<Activity size={18} />}
+            label="Gateway"
+            active={location.pathname === '/gateway'}
+          />
+          <NavItem
+            to="/hosts"
+            icon={<Server size={18} />}
+            label="Hosts & Instances"
+            active={location.pathname === '/hosts'}
+          />
+          <NavItem
+            to="/intents"
+            icon={<Target size={18} />}
+            label="Intents"
+            active={location.pathname.startsWith('/intents')}
+          />
+          <NavItem
+            to="/resources"
+            icon={<Gauge size={18} />}
+            label="Resources"
+            active={location.pathname === '/resources'}
+          />
+          <NavItem
+            to="/endpoints"
+            icon={<Key size={18} />}
+            label="Endpoints"
+            active={location.pathname === '/endpoints'}
+          />
+          <NavItem
+            to="/catalog"
+            icon={<Database size={18} />}
+            label="Catalog"
+            active={location.pathname === '/catalog'}
+          />
+        </div>
+
+        {/* Status + logout — pinned */}
+        <div className="ml-auto flex items-center gap-4 text-xs shrink-0">
+          <div className="flex items-center gap-2">
+            <span className={isConnected ? 'text-nord-14' : 'text-nord-11'}>●</span>
+            <span className="text-nord-4">Event Stream</span>
+          </div>
+          <form method="post" action="/auth/logout">
+            <button
+              type="submit"
+              className="flex items-center gap-1 rounded-md px-2 py-1 text-nord-4 transition-colors hover:bg-nord-2 hover:text-nord-6"
+            >
+              <LogOut size={14} />
+              Logout
+            </button>
+          </form>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,90 +1,89 @@
 import { Link, useLocation } from 'react-router-dom';
-import { ReactNode } from 'react';
-import { Activity, Server, Target, Gauge, Key, Database, LogOut } from 'lucide-react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
+import { Activity, Server, Target, Gauge, Key, Database, LogOut, Menu, X } from 'lucide-react';
 import { useRoutingEventsContext } from '@/context/RoutingEventsContext';
 
-function NavItem({ to, icon, label, active }: { to: string; icon: ReactNode; label: string; active: boolean }) {
+type NavItemDef = {
+  to: string;
+  icon: ReactNode;
+  label: string;
+  isActive: (pathname: string) => boolean;
+};
+
+const NAV_ITEMS: NavItemDef[] = [
+  { to: '/routing', icon: <Activity size={18} />, label: 'Routing', isActive: (p) => p === '/routing' },
+  { to: '/gateway', icon: <Activity size={18} />, label: 'Gateway', isActive: (p) => p === '/gateway' },
+  { to: '/hosts', icon: <Server size={18} />, label: 'Hosts & Instances', isActive: (p) => p === '/hosts' },
+  { to: '/intents', icon: <Target size={18} />, label: 'Intents', isActive: (p) => p.startsWith('/intents') },
+  { to: '/resources', icon: <Gauge size={18} />, label: 'Resources', isActive: (p) => p === '/resources' },
+  { to: '/endpoints', icon: <Key size={18} />, label: 'Endpoints', isActive: (p) => p === '/endpoints' },
+  { to: '/catalog', icon: <Database size={18} />, label: 'Catalog', isActive: (p) => p === '/catalog' },
+];
+
+function NavLink({ item, onNavigate, fullWidth }: { item: NavItemDef; onNavigate?: () => void; fullWidth?: boolean }) {
+  const location = useLocation();
+  const active = item.isActive(location.pathname);
   return (
     <Link
-      to={to}
+      to={item.to}
+      onClick={onNavigate}
       className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors whitespace-nowrap shrink-0 ${
-        active ? 'bg-nord-10 text-nord-6 font-medium' : 'text-nord-4 hover:bg-nord-2'
-      }`}
+        fullWidth ? 'w-full' : ''
+      } ${active ? 'bg-nord-10 text-nord-6 font-medium' : 'text-nord-4 hover:bg-nord-2'}`}
     >
-      {icon}
-      {label}
+      {item.icon}
+      {item.label}
     </Link>
   );
 }
 
 export function Navigation() {
-  const location = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const navRef = useRef<HTMLElement>(null);
   let isConnected = false;
   try {
     const ctx = useRoutingEventsContext();
     isConnected = ctx.routingConnected;
   } catch {}
 
+  // Close the collapsed menu on Escape or when clicking outside the nav bar.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false);
+    };
+    const onPointerDown = (e: PointerEvent) => {
+      if (navRef.current && !navRef.current.contains(e.target as Node)) setMenuOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('pointerdown', onPointerDown);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('pointerdown', onPointerDown);
+    };
+  }, [menuOpen]);
+
   return (
-    <nav className="bg-nord-1 border-b border-nord-3 px-6 py-3">
-      <div className="flex items-center gap-6 min-w-0">
+    <nav ref={navRef} className="relative bg-nord-1 border-b border-nord-3 px-4 sm:px-6 py-3">
+      <div className="flex items-center gap-3 sm:gap-6 min-w-0">
         {/* Logo — pinned */}
-        <div className="flex items-center gap-2 mr-8 shrink-0">
+        <div className="flex items-center gap-2 mr-4 sm:mr-8 shrink-0">
           <Activity className="text-nord-8" size={24} />
           <span className="font-bold text-xl text-nord-6">Solar</span>
         </div>
 
-        {/* Link strip — scrolls internally on narrow viewports */}
-        <div className="flex-1 min-w-0 flex items-center gap-1 overflow-x-auto no-scrollbar">
-          <NavItem
-            to="/routing"
-            icon={<Activity size={18} />}
-            label="Routing"
-            active={location.pathname === '/routing'}
-          />
-          <NavItem
-            to="/gateway"
-            icon={<Activity size={18} />}
-            label="Gateway"
-            active={location.pathname === '/gateway'}
-          />
-          <NavItem
-            to="/hosts"
-            icon={<Server size={18} />}
-            label="Hosts & Instances"
-            active={location.pathname === '/hosts'}
-          />
-          <NavItem
-            to="/intents"
-            icon={<Target size={18} />}
-            label="Intents"
-            active={location.pathname.startsWith('/intents')}
-          />
-          <NavItem
-            to="/resources"
-            icon={<Gauge size={18} />}
-            label="Resources"
-            active={location.pathname === '/resources'}
-          />
-          <NavItem
-            to="/endpoints"
-            icon={<Key size={18} />}
-            label="Endpoints"
-            active={location.pathname === '/endpoints'}
-          />
-          <NavItem
-            to="/catalog"
-            icon={<Database size={18} />}
-            label="Catalog"
-            active={location.pathname === '/catalog'}
-          />
+        {/* Link strip — desktop only; scrolls internally if space runs out */}
+        <div className="hidden xl:flex flex-1 min-w-0 items-center gap-1 overflow-x-auto no-scrollbar">
+          {NAV_ITEMS.map((item) => (
+            <NavLink key={item.to} item={item} />
+          ))}
         </div>
 
-        {/* Status + logout — pinned */}
-        <div className="ml-auto flex items-center gap-4 text-xs shrink-0">
+        {/* Status + logout + menu toggle — pinned */}
+        <div className="ml-auto flex items-center gap-3 sm:gap-4 text-xs shrink-0">
           <div className="flex items-center gap-2">
             <span className={isConnected ? 'text-nord-14' : 'text-nord-11'}>●</span>
-            <span className="text-nord-4">Event Stream</span>
+            <span className="text-nord-4 hidden sm:inline">Event Stream</span>
           </div>
           <form method="post" action="/auth/logout">
             <button
@@ -92,11 +91,29 @@ export function Navigation() {
               className="flex items-center gap-1 rounded-md px-2 py-1 text-nord-4 transition-colors hover:bg-nord-2 hover:text-nord-6"
             >
               <LogOut size={14} />
-              Logout
+              <span className="hidden sm:inline">Logout</span>
             </button>
           </form>
+          <button
+            type="button"
+            onClick={() => setMenuOpen((open) => !open)}
+            aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+            aria-expanded={menuOpen}
+            className="xl:hidden p-2 rounded-lg text-nord-4 transition-colors hover:bg-nord-2 hover:text-nord-6"
+          >
+            {menuOpen ? <X size={20} /> : <Menu size={20} />}
+          </button>
         </div>
       </div>
+
+      {/* Collapsed menu — dropdown under the bar on tablet/mobile widths */}
+      {menuOpen && (
+        <div className="xl:hidden absolute right-4 sm:right-6 top-full mt-2 w-64 rounded-lg border border-nord-3 bg-nord-1 shadow-xl p-2 z-50 flex flex-col gap-0.5">
+          {NAV_ITEMS.map((item) => (
+            <NavLink key={item.to} item={item} fullWidth onNavigate={() => setMenuOpen(false)} />
+          ))}
+        </div>
+      )}
     </nav>
   );
 }

--- a/src/components/ResourceBar.tsx
+++ b/src/components/ResourceBar.tsx
@@ -1,0 +1,67 @@
+import { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ResourceBarSegment {
+  key: string;
+  label: string; // tooltip text, e.g. "Inference — 2 instances"
+  gb: number | null | undefined;
+  className: string; // fill classes, e.g. 'bg-nord-10'
+}
+
+interface ResourceBarProps {
+  dimLabel: string; // 'VRAM' | 'RAM' | 'Disk'
+  icon?: ReactNode;
+  totalGb: number | null | undefined;
+  segments: ResourceBarSegment[]; // rendered in order; widths proportional to gb/total
+  availableGb: number | null | undefined; // authoritative free value from the API (S-034)
+  unavailable?: boolean; // true → render dashes instead of a bar
+}
+
+export function ResourceBar({ dimLabel, icon, totalGb, segments, availableGb, unavailable }: ResourceBarProps) {
+  const total = totalGb ?? 0;
+  const pct = (gb: number | null | undefined) =>
+    total > 0 ? Math.max(0, Math.min(100, ((gb ?? 0) / total) * 100)) : 0;
+
+  if (unavailable) {
+    return (
+      <div className="space-y-1">
+        <div className="flex items-center justify-between text-xs text-nord-4">
+          <span className="font-medium flex items-center gap-1">
+            {icon}
+            {dimLabel}:
+          </span>
+          <span>—</span>
+        </div>
+        <div className="w-full h-2.5 bg-nord-2 rounded-full opacity-40" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs text-nord-4">
+        <span className="font-medium flex items-center gap-1">
+          {icon}
+          {dimLabel}:
+        </span>
+        <span>
+          {totalGb != null && availableGb != null
+            ? `${(totalGb - availableGb).toFixed(1)} / ${totalGb.toFixed(1)} GB (${
+                totalGb > 0 ? (((totalGb - availableGb) / totalGb) * 100).toFixed(1) : '0.0'
+              }%)`
+            : '—'}
+        </span>
+      </div>
+      <div className="w-full h-2.5 bg-nord-2 rounded-full overflow-hidden flex">
+        {segments.map((seg) => (
+          <div
+            key={seg.key}
+            className={cn('h-full transition-all duration-300', seg.className)}
+            style={{ width: `${pct(seg.gb)}%` }}
+            title={seg.gb != null ? `${seg.label}: ${seg.gb.toFixed(1)} GB` : seg.label}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ResourcesPage.tsx
+++ b/src/components/ResourcesPage.tsx
@@ -1,0 +1,390 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AlertCircle, AlertTriangle, Gauge, RefreshCw } from 'lucide-react';
+import solarClient from '@/api/client';
+import { AggregatedResourceResponse } from '@/api/types';
+import { useRoutingEventsContext } from '@/context/RoutingEventsContext';
+import { cn, formatRelativeTime } from '@/lib/utils';
+import { HostResourceCard } from './HostResourceCard';
+
+const fmtGb = (value: number | null | undefined): string => (value == null ? '—' : `${value.toFixed(1)} GB`);
+
+const toGbParam = (s: string): number | undefined =>
+  s.trim() !== '' && Number.isFinite(Number(s)) ? Number(s) : undefined;
+
+function StatCard({
+  label,
+  value,
+  sub,
+  valueClass,
+  title,
+}: {
+  label: string;
+  value: string;
+  sub?: React.ReactNode;
+  valueClass?: string;
+  title?: string;
+}) {
+  return (
+    <div className="bg-nord-1 border border-nord-3 rounded p-4" title={title}>
+      <div className="text-nord-4 text-sm">{label}</div>
+      <div className={cn('text-nord-6 text-2xl font-semibold mt-0.5', valueClass)}>{value}</div>
+      {sub && <div className="text-nord-4 text-xs mt-1">{sub}</div>}
+    </div>
+  );
+}
+
+interface SummaryTotals {
+  vram: { total: number; hosts: number };
+  ram: { total: number; hosts: number };
+  disk: { total: number; hosts: number };
+  vramTraining: { total: number; hosts: number };
+  maxFreeVramTraining: number | null;
+  freeVramByGpuType: Record<string, number>;
+}
+
+const EMPTY_SUMMARY: SummaryTotals = {
+  vram: { total: 0, hosts: 0 },
+  ram: { total: 0, hosts: 0 },
+  disk: { total: 0, hosts: 0 },
+  vramTraining: { total: 0, hosts: 0 },
+  maxFreeVramTraining: null,
+  freeVramByGpuType: {},
+};
+
+export function ResourcesPage() {
+  const [data, setData] = useState<AggregatedResourceResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [live, setLive] = useState(true);
+  const [roleFilter, setRoleFilter] = useState('all'); // all | training | inference
+  const [gpuTypeFilter, setGpuTypeFilter] = useState('all'); // all | nvidia_cuda | apple_mps | cpu
+  const [minVram, setMinVram] = useState(''); // GB threshold input, '' = none
+  const [minRam, setMinRam] = useState(''); // GB threshold input, '' = none
+  const [appliedMinVram, setAppliedMinVram] = useState(''); // committed on Enter/blur
+  const [appliedMinRam, setAppliedMinRam] = useState(''); // committed on Enter/blur
+
+  const { hostStatuses, hostInstances, routingConnected } = useRoutingEventsContext();
+
+  const fetchResources = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await solarClient.getResources({
+        role: roleFilter !== 'all' ? roleFilter : undefined,
+        gpu_type: gpuTypeFilter !== 'all' ? gpuTypeFilter : undefined,
+        min_available_vram_gb: toGbParam(appliedMinVram),
+        min_available_ram_gb: toGbParam(appliedMinRam),
+      });
+      setData(res);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch resources');
+    } finally {
+      setLoading(false);
+    }
+  }, [roleFilter, gpuTypeFilter, appliedMinVram, appliedMinRam]);
+
+  // Initial load + refetch when committed filters change
+  useEffect(() => {
+    fetchResources();
+  }, [fetchResources]);
+
+  // Event-driven refresh: refetch (debounced) only when the live stream signature changes
+  const streamSignature = useMemo(() => {
+    const hostSig = Array.from(hostStatuses.values())
+      .map((h) => `${h.host_id}:${h.status}:${h.memory?.used_gb ?? ''}:${h.memory_available_gb ?? ''}`)
+      .sort()
+      .join('|');
+    const instSig = Array.from(hostInstances.entries())
+      .map(([id, insts]) => `${id}:${insts.length}`)
+      .sort()
+      .join('|');
+    return `${hostSig}::${instSig}`;
+  }, [hostStatuses, hostInstances]);
+
+  useEffect(() => {
+    if (!live) return;
+    const t = window.setTimeout(() => fetchResources(), 1500);
+    return () => window.clearTimeout(t);
+  }, [streamSignature, live, fetchResources]);
+
+  // Periodic refresh fallback (tighter than GatewayDashboard — resource data moves with workloads)
+  useEffect(() => {
+    if (!live) return;
+    const interval = routingConnected ? 60000 : 20000;
+    const id = window.setInterval(() => fetchResources(), interval);
+    return () => window.clearInterval(id);
+  }, [live, routingConnected, fetchResources]);
+
+  // Summary: group API-provided available values over reachable snapshots — never re-derive
+  const summary: SummaryTotals = useMemo(() => {
+    if (!data) return EMPTY_SUMMARY;
+    const reachable = data.hosts.filter((h) => h.reachable);
+    const sum = (dim: 'vram' | 'ram' | 'disk') => {
+      let total = 0;
+      let hosts = 0;
+      for (const h of reachable) {
+        const v = h[`${dim}_available_gb`];
+        if (v != null) {
+          total += v;
+          hosts += 1;
+        }
+      }
+      return { total, hosts };
+    };
+    const trainingHosts = reachable.filter((h) => h.roles.includes('training'));
+    const vramTraining = { total: 0, hosts: 0 };
+    let maxFreeVramTraining: number | null = null;
+    const freeVramByGpuType: Record<string, number> = {};
+    for (const h of trainingHosts) {
+      const v = h.vram_available_gb;
+      if (v == null) continue;
+      vramTraining.total += v;
+      vramTraining.hosts += 1;
+      if (maxFreeVramTraining == null || v > maxFreeVramTraining) maxFreeVramTraining = v;
+      const gpu = h.gpu_type ?? 'unknown';
+      freeVramByGpuType[gpu] = (freeVramByGpuType[gpu] ?? 0) + v;
+    }
+    return {
+      vram: sum('vram'),
+      ram: sum('ram'),
+      disk: sum('disk'),
+      vramTraining,
+      maxFreeVramTraining,
+      freeVramByGpuType,
+    };
+  }, [data]);
+
+  const lastUpdated = useMemo(() => {
+    let max: string | null = null;
+    for (const h of data?.hosts ?? []) {
+      if (h.snapshot_timestamp && (max == null || h.snapshot_timestamp > max)) max = h.snapshot_timestamp;
+    }
+    return max ?? undefined;
+  }, [data]);
+
+  const gpuBreakdown = Object.entries(summary.freeVramByGpuType)
+    .map(([gpu, v]) => `${gpu}: ${v.toFixed(1)} GB`)
+    .join(' · ');
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center justify-center" style={{ height: 'calc(100vh - 60px)' }}>
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-nord-9 mx-auto mb-4"></div>
+          <p className="text-nord-4">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto p-6 space-y-8">
+      {/* Header: title + filters + Auto/Manual + Refresh + updated-at */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-3">
+          <Gauge className="text-nord-8" />
+          <h1 className="text-2xl font-semibold text-nord-6">Resources</h1>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            value={roleFilter}
+            onChange={(e) => setRoleFilter(e.target.value)}
+            className="bg-nord-2 text-nord-6 border border-nord-3 rounded px-2 py-1"
+            title="Filter hosts by role"
+          >
+            <option value="all">All roles</option>
+            <option value="training">Training</option>
+            <option value="inference">Inference</option>
+          </select>
+          <select
+            value={gpuTypeFilter}
+            onChange={(e) => setGpuTypeFilter(e.target.value)}
+            className="bg-nord-2 text-nord-6 border border-nord-3 rounded px-2 py-1"
+            title="Filter hosts by GPU type"
+          >
+            <option value="all">All GPU types</option>
+            <option value="nvidia_cuda">NVIDIA CUDA</option>
+            <option value="apple_mps">Apple MPS</option>
+            <option value="cpu">CPU</option>
+          </select>
+          <label
+            className="flex items-center gap-1 text-xs text-nord-4"
+            title="Only show hosts with at least this much free VRAM"
+          >
+            Min free VRAM
+            <input
+              type="number"
+              min={0}
+              value={minVram}
+              onChange={(e) => setMinVram(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') setAppliedMinVram(minVram);
+              }}
+              onBlur={() => setAppliedMinVram(minVram)}
+              placeholder="GB"
+              className="bg-nord-2 text-nord-6 border border-nord-3 rounded px-2 py-1 w-20"
+            />
+          </label>
+          <label
+            className="flex items-center gap-1 text-xs text-nord-4"
+            title="Only show hosts with at least this much free RAM"
+          >
+            Min free RAM
+            <input
+              type="number"
+              min={0}
+              value={minRam}
+              onChange={(e) => setMinRam(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') setAppliedMinRam(minRam);
+              }}
+              onBlur={() => setAppliedMinRam(minRam)}
+              placeholder="GB"
+              className="bg-nord-2 text-nord-6 border border-nord-3 rounded px-2 py-1 w-20"
+            />
+          </label>
+          <button
+            onClick={() => setLive((v) => !v)}
+            className={`px-3 py-2 rounded ${live ? 'bg-nord-10 text-nord-6' : 'bg-nord-3 text-nord-6 hover:bg-nord-2'}`}
+            title={live ? 'Auto-refresh enabled' : 'Enable auto-refresh'}
+          >
+            {live ? 'Auto' : 'Manual'}
+          </button>
+          <button
+            onClick={() => fetchResources()}
+            className="px-3 py-2 bg-nord-3 text-nord-6 rounded hover:bg-nord-2 flex items-center gap-2"
+            title="Refresh now"
+          >
+            <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+            Refresh
+          </button>
+          <span className="text-xs text-nord-4">Updated {formatRelativeTime(lastUpdated)}</span>
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-nord-11 bg-opacity-20 border border-nord-11 rounded-lg p-4 flex items-center gap-2 text-nord-6">
+          <AlertCircle size={18} className="shrink-0 text-nord-11" />
+          <span className="text-sm">{error}</span>
+        </div>
+      )}
+
+      {data && data.unreachable_hosts > 0 && (
+        <div className="flex items-center gap-2 text-sm text-nord-12">
+          <AlertTriangle size={16} className="shrink-0" />
+          <span>
+            {data.unreachable_hosts} host{data.unreachable_hosts === 1 ? '' : 's'} unreachable — excluded from totals
+          </span>
+        </div>
+      )}
+
+      {data && data.hosts.length === 0 ? (
+        <div className="text-center py-16 text-nord-4">
+          <p className="text-lg">No hosts match the current filters</p>
+          <p className="text-sm mt-2">
+            Adjust the filters above, or check{' '}
+            <Link to="/hosts" className="text-nord-8 hover:underline">
+              Hosts &amp; Instances
+            </Link>{' '}
+            to see configured hosts.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Summary strip */}
+          <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-4">
+            <StatCard
+              label="Hosts"
+              value={`${data?.reachable_hosts ?? 0} / ${data?.total_hosts ?? 0}`}
+              sub={
+                (data?.unreachable_hosts ?? 0) > 0 ? (
+                  <span className="text-nord-11">{data?.unreachable_hosts} unreachable</span>
+                ) : (
+                  'reachable / total'
+                )
+              }
+            />
+            <StatCard
+              label="Free VRAM"
+              value={summary.vram.hosts > 0 ? fmtGb(summary.vram.total) : '—'}
+              sub={
+                summary.vram.hosts > 0
+                  ? `across ${summary.vram.hosts} host${summary.vram.hosts === 1 ? '' : 's'}`
+                  : 'no host reports VRAM'
+              }
+              title="Sum of available VRAM over reachable hosts in current filter"
+            />
+            <StatCard
+              label="Free VRAM (training)"
+              value={summary.vramTraining.hosts > 0 ? fmtGb(summary.vramTraining.total) : '—'}
+              sub={
+                summary.vramTraining.hosts > 0
+                  ? `across ${summary.vramTraining.hosts} training host${summary.vramTraining.hosts === 1 ? '' : 's'}`
+                  : 'no training host reports VRAM'
+              }
+              title="Sum of available VRAM over reachable training-capable hosts"
+            />
+            <StatCard
+              label="Free RAM"
+              value={summary.ram.hosts > 0 ? fmtGb(summary.ram.total) : '—'}
+              sub={
+                summary.ram.hosts > 0
+                  ? `across ${summary.ram.hosts} host${summary.ram.hosts === 1 ? '' : 's'}`
+                  : 'no host reports RAM'
+              }
+            />
+            <StatCard
+              label="Free Disk"
+              value={summary.disk.hosts > 0 ? fmtGb(summary.disk.total) : '—'}
+              sub={
+                summary.disk.hosts > 0
+                  ? `across ${summary.disk.hosts} host${summary.disk.hosts === 1 ? '' : 's'}`
+                  : 'no host reports disk'
+              }
+            />
+            <StatCard
+              label="Fits? (training)"
+              value={summary.maxFreeVramTraining != null ? fmtGb(summary.maxFreeVramTraining) : '—'}
+              sub={gpuBreakdown || 'no training host reports VRAM'}
+              title="Max free VRAM on a single training-capable host — can we fit a training job?"
+            />
+          </div>
+
+          {/* Host cards */}
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+            {data?.hosts.map((h) => (
+              <HostResourceCard key={h.host_id} snapshot={h} />
+            ))}
+          </div>
+
+          {/* Legend + semantics footnote */}
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-nord-4">
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-3.5 h-2.5 rounded-sm bg-nord-10" />
+                Inference
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-3.5 h-2.5 rounded-sm bg-nord-15" />
+                Training (job steps)
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-3.5 h-2.5 rounded-sm bg-nord-13" />
+                Reserved (pending)
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-3.5 h-2.5 rounded-sm bg-nord-2" />
+                Free (available)
+              </span>
+            </div>
+            <p className="text-xs text-nord-4">
+              available = total − Σeffective · effective = max(actual, requested) (S-034/S-035) — values as reported by
+              the scheduler, never recomputed client-side
+            </p>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ResourcesPage.tsx
+++ b/src/components/ResourcesPage.tsx
@@ -379,8 +379,7 @@ export function ResourcesPage() {
               </span>
             </div>
             <p className="text-xs text-nord-4">
-              available = total − Σeffective · effective = max(actual, requested) (S-034/S-035) — values as reported by
-              the scheduler, never recomputed client-side
+              available = total − Σeffective · effective = max(actual, requested)
             </p>
           </div>
         </>

--- a/src/hooks/useEventStream.ts
+++ b/src/hooks/useEventStream.ts
@@ -15,7 +15,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { io, Socket } from 'socket.io-client';
 import solarClient from '@/api/client';
-import { MemoryInfo, LogMessage, PendingHost, Intent } from '@/api/types';
+import { MemoryInfo, LogMessage, PendingHost, Intent, ActiveJobSummary } from '@/api/types';
 
 // Event type definitions
 export type WSMessageType =
@@ -63,6 +63,7 @@ export interface HostStatusData {
   connected?: boolean;
   last_seen?: string;
   timestamp?: string;
+  active_jobs?: ActiveJobSummary[];
 }
 
 export interface LogEventData {

--- a/src/index.css
+++ b/src/index.css
@@ -68,3 +68,12 @@
 ::-webkit-scrollbar-thumb:hover {
   background: #5e81ac; /* nord10 */
 }
+
+/* Hide scrollbar on horizontally scrollable strips (e.g. top navigation) */
+.no-scrollbar {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -62,6 +62,46 @@ export function formatUptime(startedAt: string | undefined): string {
   return `${seconds}s`;
 }
 
+/** Human-readable GPU type label (host cards, resource dashboard). */
+export function getGpuTypeLabel(gpuType: string): string {
+  switch (gpuType) {
+    case 'nvidia_cuda':
+      return 'NVIDIA CUDA';
+    case 'apple_mps':
+      return 'Apple MPS';
+    case 'cpu':
+      return 'CPU';
+    default:
+      return gpuType;
+  }
+}
+
+/** Badge classes for GPU type (host cards, resource dashboard). */
+export function getGpuTypeBadgeClass(gpuType: string): string {
+  switch (gpuType) {
+    case 'nvidia_cuda':
+      return 'bg-nord-14 text-nord-6';
+    case 'apple_mps':
+      return 'bg-nord-15 text-nord-6';
+    case 'cpu':
+      return 'bg-nord-3 text-nord-6';
+    default:
+      return 'bg-nord-3 text-nord-6';
+  }
+}
+
+/** Badge classes for host role (host cards, resource dashboard). */
+export function getRoleBadgeClass(role: string): string {
+  switch (role) {
+    case 'inference':
+      return 'bg-nord-6 bg-opacity-20 text-nord-6';
+    case 'training':
+      return 'bg-nord-15 text-nord-6';
+    default:
+      return 'bg-nord-6 bg-opacity-15 text-nord-6';
+  }
+}
+
 export function getStatusColor(status: string): string {
   switch (status) {
     case 'running':


### PR DESCRIPTION
## Description
Implements the U-004 resource utilization dashboard for the Solar WebUI. Until now the UI only showed opaque used/total memory and disk bars per host — operators could not see what was consuming capacity or where a new workload could fit. The new `/resources` page visualizes the S-035 `GET /api/resources` aggregate per host and across the cluster, separating consumers (inference instances, active training job steps, pending reservations) from free capacity using the scheduler's own `available = total - Σeffective` semantics.

## Changes
- **`src/components/ResourcesPage.tsx` (new)** — cluster-wide dashboard at `/resources`:
  - Summary stat cards: total/free VRAM, RAM and disk across reachable hosts, training-capable free VRAM, largest single-host free VRAM, and free VRAM by GPU type
  - S-035 filters as UI controls: `role`, `gpu_type`, and `min_available_vram_gb` / `min_available_ram_gb` thresholds (committed on Enter/blur)
  - Event-driven refresh (debounced 1.5 s) on `host_status` / `instances_update` stream signatures, periodic refetch fallback (60 s connected, 20 s disconnected), manual refresh button and live toggle
  - Unreachable/stale hosts marked unavailable and excluded from free-capacity totals
- **`src/components/HostResourceCard.tsx` (new)** — per-host allocation breakdown with segmented VRAM/RAM/disk bars (inference instances, training job steps, reservations, available) plus a workloads panel listing instance aliases, active jobs (job id, step, status) and reservations (owner job id, workload type, status)
- **`src/components/ResourceBar.tsx` (new)** — reusable segmented bar whose free segment always uses the API-provided available value (no client-side re-derivation)
- **`src/api/client.ts` / `src/api/types.ts`** — `solarClient.getResources(params)` plus full typed resource aggregates (`HostResourceSnapshot`, `ActiveJobSummary`, `HostInstanceSummary`, `HostReservationSummary`, `AggregatedResourceResponse`, `ResourcesQueryParams`)
- **`src/components/Navigation.tsx` (new)** — navigation extracted from `App.tsx`, responsive (collapsed menu on small screens, Escape/outside-click close), new Resources entry
- **`src/lib/utils.ts`** — shared `getGpuTypeLabel` / `getGpuTypeBadgeClass` / `getRoleBadgeClass` helpers (deduplicated from `HostCard.tsx`)
- **`src/hooks/useEventStream.ts`** — `HostStatusData` carries `active_jobs` for event-driven updates

## Related Issues
Closes #24
